### PR TITLE
Add internal metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- Use a [configuration file](chainpulse.toml) instead of command-line arguments
 - Add support for listening on multiple chains simultaneously
+- Use a [configuration file](./README.md#configuration) instead of command-line arguments
+- Add [internal metrics](./README.md/#internal-metrics)
 
 ## v0.1.2
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,51 @@ $ chainpulse --config chainpulse.toml
 
 The built-in HTTP server at `/metrics` exports the following Prometheus metrics:
 
-- `ibc_effected_packets{chain_id, src_channel, src_port, dst_channel, dst_port, signer, memo}`
-- `ibc_uneffected_packets{chain_id, src_channel, src_port, dst_channel, dst_port, signer, memo}`
-- `ibc_frontrun_counter{chain_id, src_channel, src_port, dst_channel, dst_port, signer, frontrunned_by, memo, effected_memo}`
+```
+# HELP ibc_effected_packets Counts the number of IBC packets that are effected
+# TYPE ibc_effected_packets counter
+ibc_effected_packets{chain_id, src_channel, src_port, dst_channel, dst_port, signer, memo}
+```
+
+```
+# HELP ibc_uneffected_packets Counts the number of IBC packets that are not effected
+# TYPE ibc_uneffected_packets counter
+ibc_uneffected_packets{chain_id, src_channel, src_port, dst_channel, dst_port, signer, memo}
+```
+
+```
+# HELP ibc_frontrun_counter Counts the number of times a signer gets frontrun by the same original signer
+# TYPE ibc_frontrun_counter counter
+ibc_frontrun_counter{chain_id, src_channel, src_port, dst_channel, dst_port, signer, frontrunned_by, memo, effected_memo}
+```
+
+### Internal metrics
+
+The following internal metrics are also available, for monitor Chain Pulse itself:
+
+```
+# HELP chainpulse_chains The number of chains being monitored
+# TYPE chainpulse_chains gauge
+chainpulse_chains 2
+```
+
+```
+# HELP chainpulse_packets The number of packets processed
+# TYPE chainpulse_packets counter
+chainpulse_packets{chain_id}
+```
+
+```
+# HELP chainpulse_reconnects The number of times we had to reconnect to the WebSocket
+# TYPE chainpulse_reconnects counter
+chainpulse_reconnects{chain_id}
+```
+
+```
+# HELP chainpulse_txs The number of txs processed
+# TYPE chainpulse_txs counter
+chainpulse_txs{chain_id}
+```
 
 ## Attribution
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+use tendermint::chain;
 use tendermint_rpc::WebSocketClientUrl;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29,7 +30,7 @@ pub struct Chains {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoint {
-    pub name: String,
+    pub name: chain::Id,
     pub url: WebSocketClientUrl,
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,12 +2,14 @@ use std::net::SocketAddr;
 
 use axum::{extract::State, routing::get, Router, Server};
 use prometheus::{
-    register_int_gauge_vec_with_registry, Encoder, IntGaugeVec, Registry, TextEncoder,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, Encoder,
+    IntCounterVec, IntGaugeVec, Registry, TextEncoder,
 };
 use tendermint::chain;
 use tracing::info;
 
 type GaugeVec = IntGaugeVec;
+type CounterVec = IntCounterVec;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -15,20 +17,46 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 pub struct Metrics {
     /// Counts the number of IBC packets that are effected
     /// Labels: ['chain_id', 'src_channel', 'src_port', 'dst_channel', 'dst_port', 'signer', 'memo']
-    ibc_effected_packets: GaugeVec,
+    ibc_effected_packets: CounterVec,
+
     /// Counts the number of IBC packets that are not effected
     /// Labels: ['chain_id', 'src_channel', 'src_port', 'dst_channel', 'dst_port', 'signer', 'memo']
-    ibc_uneffected_packets: GaugeVec,
+    ibc_uneffected_packets: CounterVec,
+
     /// Counts the number of times a signer gets frontrun by the same original signer
     /// Labels: ['chain_id', 'src_channel', 'src_port', 'dst_channel', 'dst_port', 'signer', 'frontrunned_by', 'memo', 'effected_memo']
-    ibc_frontrun_counter: GaugeVec,
+    ibc_frontrun_counter: CounterVec,
+
+    /// The number of chains being monitored
+    chainpulse_chains: GaugeVec,
+
+    /// The number of txs processed
+    /// Labels: ['chain_id']
+    chainpulse_txs: CounterVec,
+
+    /// The number of packets processed
+    /// Labels: ['chain_id']
+    chainpulse_packets: CounterVec,
+
+    /// The number of times we had to reconnect to the WebSocket
+    /// Labels: ['chain_id']
+    chainpulse_reconnects: CounterVec,
+
+    /// The number of times the WebSocket connection timed out
+    /// Labels: 'chain_id']
+    /// []
+    chainpulse_timeouts: CounterVec,
+
+    /// The number of times we encountered an error
+    /// Labels: ['chain_id']
+    chainpulse_errors: CounterVec,
 }
 
 impl Metrics {
     pub fn new() -> (Self, Registry) {
         let registry = Registry::new();
 
-        let ibc_effected_packets = register_int_gauge_vec_with_registry!(
+        let ibc_effected_packets = register_int_counter_vec_with_registry!(
             "ibc_effected_packets",
             "Counts the number of IBC packets that are effected",
             &[
@@ -40,11 +68,11 @@ impl Metrics {
                 "signer",
                 "memo",
             ],
-            registry
+            registry,
         )
         .unwrap();
 
-        let ibc_uneffected_packets = register_int_gauge_vec_with_registry!(
+        let ibc_uneffected_packets = register_int_counter_vec_with_registry!(
             "ibc_uneffected_packets",
             "Counts the number of IBC packets that are not effected",
             &[
@@ -60,7 +88,7 @@ impl Metrics {
         )
         .unwrap();
 
-        let ibc_frontrun_counter = register_int_gauge_vec_with_registry!(
+        let ibc_frontrun_counter = register_int_counter_vec_with_registry!(
             "ibc_frontrun_counter",
             "Counts the number of times a signer gets frontrun by the same original signer",
             &[
@@ -78,11 +106,65 @@ impl Metrics {
         )
         .unwrap();
 
+        let chainpulse_chains = register_int_gauge_vec_with_registry!(
+            "chainpulse_chains",
+            "The number of chains being monitored",
+            &[],
+            registry
+        )
+        .unwrap();
+
+        let chainpulse_txs = register_int_counter_vec_with_registry!(
+            "chainpulse_txs",
+            "The number of txs processed",
+            &["chain_id"],
+            registry
+        )
+        .unwrap();
+
+        let chainpulse_packets = register_int_counter_vec_with_registry!(
+            "chainpulse_packets",
+            "The number of packets processed",
+            &["chain_id"],
+            registry
+        )
+        .unwrap();
+
+        let chainpulse_reconnects = register_int_counter_vec_with_registry!(
+            "chainpulse_reconnects",
+            "The number of times we had to reconnect to the WebSocket",
+            &["chain_id"],
+            registry
+        )
+        .unwrap();
+
+        let chainpulse_timeouts = register_int_counter_vec_with_registry!(
+            "chainpulse_timeouts",
+            "The number of times the WebSocket connection timed out",
+            &["chain_id"],
+            registry
+        )
+        .unwrap();
+
+        let chainpulse_errors = register_int_counter_vec_with_registry!(
+            "chainpulse_errors",
+            "The number of times an error was encountered",
+            &["chain_id"],
+            registry
+        )
+        .unwrap();
+
         (
             Self {
                 ibc_effected_packets,
                 ibc_uneffected_packets,
                 ibc_frontrun_counter,
+                chainpulse_chains,
+                chainpulse_txs,
+                chainpulse_packets,
+                chainpulse_reconnects,
+                chainpulse_timeouts,
+                chainpulse_errors,
             },
             registry,
         )
@@ -161,6 +243,40 @@ impl Metrics {
                 memo,
                 effected_memo,
             ])
+            .inc();
+    }
+
+    pub fn chainpulse_chains(&self) {
+        self.chainpulse_chains.with_label_values(&[]).inc();
+    }
+
+    pub fn chainpulse_txs(&self, chain_id: &chain::Id) {
+        self.chainpulse_txs
+            .with_label_values(&[chain_id.as_ref()])
+            .inc();
+    }
+
+    pub fn chainpulse_packets(&self, chain_id: &chain::Id) {
+        self.chainpulse_packets
+            .with_label_values(&[chain_id.as_ref()])
+            .inc();
+    }
+
+    pub fn chainpulse_reconnects(&self, chain_id: &chain::Id) {
+        self.chainpulse_reconnects
+            .with_label_values(&[chain_id.as_ref()])
+            .inc();
+    }
+
+    pub fn chainpulse_timeouts(&self, chain_id: &chain::Id) {
+        self.chainpulse_timeouts
+            .with_label_values(&[chain_id.as_ref()])
+            .inc();
+    }
+
+    pub fn chainpulse_errors(&self, chain_id: &chain::Id) {
+        self.chainpulse_errors
+            .with_label_values(&[chain_id.as_ref()])
             .inc();
     }
 }


### PR DESCRIPTION
```
# HELP chainpulse_chains The number of chains being monitored
# TYPE chainpulse_chains gauge
chainpulse_chains 2
# HELP chainpulse_packets The number of packets processed
# TYPE chainpulse_packets counter
chainpulse_packets{chain_id="neutron-1"} 40
chainpulse_packets{chain_id="osmosis-1"} 249
# HELP chainpulse_reconnects The number of times we had to reconnect to the WebSocket
# TYPE chainpulse_reconnects counter
chainpulse_reconnects{chain_id="osmosis"} 2
# HELP chainpulse_txs The number of txs processed
# TYPE chainpulse_txs counter
chainpulse_txs{chain_id="neutron-1"} 22
chainpulse_txs{chain_id="osmosis-1"} 854
```