### PR TITLE
Add option to populate metrics on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,22 @@
 
 ## Unreleased
 
-> Nothing yet
+- Add a `populate_on_start` option to the `[metrics]` section in the configuration file to
+  populate the Prometheus metrics on start by replaying all packets present in the database so far
+  ([#8](https://github.com/informalsystems/chainpulse/pull/8))
 
 ## v0.2.0
 
 *May 26th 2023*
 
-- Add support for listening on multiple chains simultaneously (https://github.com/informalsystems/chainpulse/pull/1)
-- Use a [configuration file](./README.md#configuration) instead of command-line arguments (https://github.com/informalsystems/chainpulse/pull/1)
-- Add [internal metrics](./README.md/#internal-metrics) (https://github.com/informalsystems/chainpulse/pull/2)
-- Add support for CometBFT 0.34 and 0.37 (https://github.com/informalsystems/chainpulse/pull/4)
+- Add support for listening on multiple chains simultaneously
+  ([#1](https://github.com/informalsystems/chainpulse/pull/1))
+- Use a [configuration file](./README.md#configuration) instead of command-line arguments
+  ([#1](https://github.com/informalsystems/chainpulse/pull/1))
+- Add [internal metrics](./README.md/#internal-metrics)
+  ([#2](https://github.com/informalsystems/chainpulse/pull/2))
+- Add support for CometBFT 0.34 and 0.37
+  ([#4](https://github.com/informalsystems/chainpulse/pull/4))
 
 ## v0.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
-- Add a `populate_on_start` option to the `[metrics]` section in the configuration file to
-  populate the Prometheus metrics on start by replaying all packets present in the database so far
+- Add a `populate_on_start` option to the `metrics` section in the configuration to
+  populate the Prometheus metrics on start by replaying all packets present in the database so far.
+  **Warning:** Use with caution if you are already tracking any of the counters with Prometheus as this
+  will result in inflated results for all counters (but not gauges or histograms).
   ([#8](https://github.com/informalsystems/chainpulse/pull/8))
 
 ## v0.2.0

--- a/chainpulse.toml
+++ b/chainpulse.toml
@@ -10,5 +10,3 @@ path = "data.db"
 [metrics]
 enabled = true
 port    = 3000
-
-populate_on_start = false

--- a/chainpulse.toml
+++ b/chainpulse.toml
@@ -1,7 +1,7 @@
 [chains]
 endpoints = [
-  { name = "neutron", comet_version = "0.34", url = "wss://neutron-rpc.lavenderfive.com/websocket" },
-  { name = "osmosis", comet_version = "0.34", url = "wss://rpc.osmosis.zone/websocket" },
+  { name = "neutron-1", comet_version = "0.34", url = "wss://neutron-rpc.lavenderfive.com/websocket" },
+  { name = "osmosis-1", comet_version = "0.34", url = "wss://rpc.osmosis.zone/websocket" },
 ]
 
 [database]
@@ -10,3 +10,5 @@ path = "data.db"
 [metrics]
 enabled = true
 port    = 3000
+
+populate_on_start = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,9 @@ pub struct Database {
 pub struct Metrics {
     pub enabled: bool,
     pub port: u16,
+
+    #[serde(default)]
+    pub populate_on_start: bool,
 }
 
 mod default {

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,7 +5,7 @@ use time::PrimitiveDateTime;
 
 use crate::Result;
 
-#[derive(sqlx::FromRow)]
+#[derive(Clone, Debug, sqlx::FromRow)]
 pub struct TxRow {
     pub id: i64,
     pub chain: String,
@@ -15,7 +15,7 @@ pub struct TxRow {
     pub created_at: PrimitiveDateTime,
 }
 
-#[derive(sqlx::FromRow)]
+#[derive(Clone, Debug, sqlx::FromRow)]
 pub struct PacketRow {
     pub id: i64,
     pub tx_id: i64,

--- a/src/populate.rs
+++ b/src/populate.rs
@@ -1,0 +1,85 @@
+use std::{collections::HashSet, time::Instant};
+
+use futures::StreamExt;
+use sqlx::SqlitePool;
+use tendermint::chain;
+use tracing::{error_span, info};
+
+use crate::{
+    db::{PacketRow, TxRow},
+    metrics::Metrics,
+};
+
+pub async fn run(chain: &chain::Id, pool: &SqlitePool, metrics: &Metrics) -> crate::Result<()> {
+    let _span = error_span!("populate", %chain).entered();
+
+    info!("Populating metrics...");
+
+    let start = Instant::now();
+
+    let mut packets =
+            sqlx::query_as::<_, PacketRow>(
+            "SELECT packets.* FROM packets LEFT JOIN txs ON packets.tx_id = txs.id WHERE txs.chain = ? ORDER BY id")
+                .bind(chain.as_str())
+                .fetch(pool);
+
+    let mut ids = HashSet::new();
+
+    while let Some(Ok(packet)) = packets.next().await {
+        metrics.chainpulse_packets(chain);
+
+        let tx = sqlx::query_as::<_, TxRow>("SELECT * FROM txs WHERE id = ? LIMIT 1")
+            .bind(packet.tx_id)
+            .fetch_one(pool)
+            .await?;
+
+        if !ids.contains(&tx.id) {
+            metrics.chainpulse_txs(chain);
+            ids.insert(tx.id);
+        }
+
+        if packet.effected {
+            metrics.ibc_effected_packets(
+                chain,
+                &packet.src_channel,
+                &packet.src_port,
+                &packet.dst_channel,
+                &packet.dst_port,
+                &packet.signer,
+                &tx.memo,
+            );
+        } else {
+            let effected_tx = sqlx::query_as::<_, TxRow>("SELECT * FROM txs WHERE id = ? LIMIT 1")
+                .bind(packet.effected_tx)
+                .fetch_one(pool)
+                .await?;
+
+            metrics.ibc_uneffected_packets(
+                chain,
+                &packet.src_channel,
+                &packet.src_port,
+                &packet.dst_channel,
+                &packet.dst_port,
+                &packet.signer,
+                &tx.memo,
+            );
+
+            metrics.ibc_frontrun_counter(
+                chain,
+                &packet.src_channel,
+                &packet.src_port,
+                &packet.dst_channel,
+                &packet.dst_port,
+                &packet.signer,
+                &packet.effected_signer.unwrap_or_default(),
+                &tx.memo,
+                &effected_tx.memo,
+            )
+        }
+    }
+
+    let elapsed = start.elapsed();
+    info!("Populated metrics in {elapsed:?}");
+
+    Ok(())
+}


### PR DESCRIPTION
Add `populate_on_start` option to the `[metrics]` section in the configuration file to populate the Prometheus metrics on start by replaying all packets present in the database so far.